### PR TITLE
docs: validate & document docker-compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,9 @@ git push origin feature/infra-<descripción>
     Esto es porque el worker **depende** de que exista un servicio de base de datos al que conectarse. Hay que levantar primero el contenedor de DB para que finalice el arranque.
 
 **Conclusión**: Todos los Dockerfiles son válidos. La única dependencia extra es la DB para el worker.
+
+
+
+## Pruebas locales con Docker Compose
+
+Para levantar y probar todo el stack usar la guía en [docs/docker-compose.md](docs/docker-compose.md).

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -1,0 +1,25 @@
+# Levantar el stack completo con Docker Compose
+
+Dentro de `app/`, ejecutar:
+
+```bash
+# 1. Build y levantar todos los servicios (sin seed)
+docker compose up --build -d
+
+# 2. Verificar estado de Redis y Postgres
+docker compose ps
+docker compose logs -f redis db
+
+# 3. Probar endpoints web
+curl -f http://localhost:8080/health
+curl -f http://localhost:8081/health
+
+# 4. Verificar worker
+docker compose logs -f worker
+
+# 5. (Opcional) Levantar sólo el job de seed
+docker compose --profile seed up --build -d seed
+docker compose logs -f seed
+
+# 6. Bajar todo y borrar volúmenes
+docker compose down --volumes


### PR DESCRIPTION
#30 

Como levantar  en local con Docker Compose, validar que los servicios (vote, result, worker, redis, db, seed) arrancan correctamente.