### PR TITLE
Update EKS cluster name in destroy workflow

### DIFF
--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Configurar kubectl
         run: |
-          aws eks update-kubeconfig --name voting-app-${{ github.event.inputs.environment }}-cluster --region ${{ secrets.AWS_DEFAULT_REGION }}
+          aws eks update-kubeconfig --name voting-cluster --region ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Eliminar namespace de Kubernetes
         run: |


### PR DESCRIPTION
Changed the EKS cluster name in the destroy-environment GitHub Actions workflow from a dynamic environment-based name to a static 'voting-cluster'. This simplifies the configuration and ensures the workflow targets the correct cluster.