### PR TITLE
Add workspace suffix to AWS key pair name

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -92,7 +92,7 @@ resource "tls_private_key" "ssh_key" {
 }
 
 resource "aws_key_pair" "voting_key" {
-  key_name   = "voting-key"
+  key_name   = "voting-key-${terraform.workspace}"
   public_key = tls_private_key.ssh_key.public_key_openssh
 }
 


### PR DESCRIPTION
Appends the current Terraform workspace to the AWS key pair name to ensure unique key names across different environments.